### PR TITLE
Fix references to GH exceptions

### DIFF
--- a/check_in/github_api.py
+++ b/check_in/github_api.py
@@ -151,16 +151,16 @@ class PatchedGithubIntegration(github.GithubIntegration):
                 completed=True
             )
         elif response.status_code == 403:
-            raise github.GithubException.BadCredentialsException(
+            raise github.BadCredentialsException(
                 status=response.status_code,
                 data=response.text
             )
         elif response.status_code == 404:
-            raise github.GithubException.UnknownObjectException(
+            raise github.UnknownObjectException(
                 status=response.status_code,
                 data=response.text
             )
-        raise github.GithubException.GithubException(
+        raise github.GithubException(
             status=response.status_code,
             data=response.text
         )


### PR DESCRIPTION
Note how exceptions are being imported in PyGithub's [`__init__`](https://github.com/PyGithub/PyGithub/blob/6a89eb645dc219b8c2cab6eeb283e05d3f279616/github/__init__.py#L43).